### PR TITLE
無限ループ回避、通信数削減

### DIFF
--- a/background.js
+++ b/background.js
@@ -31,8 +31,18 @@ async function set_eappid() {
 		const connecter = new api_connecter(eappid_page_url);
 		await connecter.get_method();
 		const text = await connecter.get_text();
-		var pattern = /eappid\\u0022:\\u0022(.+?)\\u0022,\\u0022/;
-		const page_eappid = text.match(pattern);
+
+		const patterns = [
+		    /eappid\u0022:\u0022(.+?)\u0022,\u0022/,
+		    /eappid\\u0022:\\u0022(.+?)\\u0022,\\u0022/,
+		];
+		let page_eappid = null;
+		for ( let pattern of patterns ) {
+			page_eappid = text.match(pattern);
+			if ( page_eappid !== null ) {
+				break;
+			}
+		}
 		console.log('取得したeappid', page_eappid);
 		if (page_eappid !== null) {
 			chrome.storage.local.set({ eappid: page_eappid[1] }, () => {});
@@ -57,14 +67,22 @@ async function is_login() {
 	const connecter = new api_connecter(eappid_page_url);
 	await connecter.get_method();
 	const html = await connecter.get_dom();
-	const no_login_dom = html.querySelector('.Personalbox__logout');
-	// このDOM要素がある時ログインしていない
-	if (no_login_dom == null) {
-		// 要素がないということはログイン済みである
-		return true;
-	} else {
-		return false;
+
+	// <div id="Login"> の中のリンクを調べる
+	// ログイン状態では
+	// - アカウント名: リンクなし
+	// - 登録情報: https://accounts.yahoo.co.jp/profile?...
+	// ログアウト状態では
+	// - ログインリンク: https://login.yahoo.co.jp/config/login?...
+	// - ID新規作成リンク: https://account.edit.yahoo.co.jp/registration?...
+	// - 登録情報: https://login.yahoo.co.jp/config/login?...
+	const a_in_login_box = html.querySelectorAll('#Login a');
+	for ( a of a_in_login_box ) {
+		if ( a.href.match(/^https:\/\/accounts.yahoo.co.jp\/profile\?/) ) {
+			return true;
+		}
 	}
+	return false;
 }
 
 async function get_mail_count() {


### PR DESCRIPTION
##  概要

ヤフー側の変更などに起因して、特定の条件で無限ループに入ってしまうケースがありましたので、修正しました。
また、通信回数をできるだけ減らすように修正しました。

## 無限ループ

以前のコードだと、以下の条件

- ログイン判定が true に判定される。
- eappid が有効なものが取れず、メール件数のAPIがエラーになる

の場合に、get_mail_count が再帰的に呼び出されて無限ループになってしまいます。
結果、ヤフーに大量にアクセスが発生し、パケ死にもつながります。

そのため以下の2段階のみで、無限には再帰しないようにしました。

- get_mail_count
    - storage に保存済みのeappidで、メール件数のAPIにアクセスする
- get_mail_count2
    - 上記が失敗した場合、ログイン判定、eappid取得をした後に、メール件数APIをアクセスする


## 差分について

ブランチの都合で、以下のPRの変更も含んでしまっています。

- ヤフー側修正で eappid とログイン状態が判断できなくなっていたのを修正 by entosen · Pull Request #1 · 53JIlLenWe11/YahooJapan_MailNotificationExtensions
https://github.com/entosen

本件のみの差分は以下です。
https://github.com/53JIlLenWe11/YahooJapan_MailNotificationExtensions/commit/10240ed4281ab3942d349d1cba80155a2b31a8bd
