### PR TITLE
[fix]仕様変更で使えなくなるURLから移行先のURLへ修正

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,7 @@
 const wait = 0.5;
 const eappid_page_url = 'https://www.yahoo.co.jp/'; // eappid と ログイン状態のチェック先
 const new_mail_count_url = 'https://web-yunz.yahoo.co.jp/Yunz/V1/getNotifications?eappid='; // メールの件数の取得先
-const open_ymail_page_url = 'https://jp.mg5.mail.yahoo.co.jp/neo/launch'; // メールの表示ページ
+const open_ymail_page_url = 'https://mail.yahoo.co.jp/u/pc/f/'; // メールの表示ページ
 
 view_new_mail_count();
 

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
 	],
 	"host_permissions": [
 		"https://www.yahoo.co.jp/",
-		"https://jp.mg5.mail.yahoo.co.jp/",
+		"https://mail.yahoo.co.jp/",
 		"https://web-yunz.yahoo.co.jp/Yunz/V1/getNotifications"
 	],
 	"action": {


### PR DESCRIPTION
background.jsの```open_ymail_page_url```、manifest.jsonの```host_permissions```を移行先URLに修正
Closes #4 